### PR TITLE
Add realtime usage cost logging

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -60,7 +60,7 @@ function App() {
     addTranscriptMessage,
     addTranscriptBreadcrumb,
   } = useTranscript();
-  const { logClientEvent, logServerEvent } = useEvent();
+  const { logClientEvent, logServerEvent, logUsageCost } = useEvent();
 
   const [selectedAgentName, setSelectedAgentName] = useState<string>("");
   const [selectedAgentConfigSet, setSelectedAgentConfigSet] = useState<
@@ -215,7 +215,7 @@ function App() {
         const companyName = agentSetKey === 'customerServiceRetail'
           ? customerServiceRetailCompanyName
           : chatSupervisorCompanyName;
-        const guardrail = createModerationGuardrail(companyName);
+        const guardrail = createModerationGuardrail(companyName, logUsageCost);
 
         await connect({
           getEphemeralKey: async () => EPHEMERAL_KEY,
@@ -224,6 +224,7 @@ function App() {
           outputGuardrails: [guardrail],
           extraContext: {
             addTranscriptBreadcrumb,
+            logUsageCost,
           },
         });
       } catch (err) {

--- a/src/app/agentConfigs/chatSupervisor/supervisorAgent.ts
+++ b/src/app/agentConfigs/chatSupervisor/supervisorAgent.ts
@@ -1,4 +1,6 @@
 import { RealtimeItem, tool } from '@openai/agents/realtime';
+import type { UsageCostLogger } from '@/app/types';
+import { normalizeUsage } from '@/app/lib/cost';
 
 
 import {
@@ -147,7 +149,14 @@ export const supervisorAgentTools = [
   },
 ];
 
-async function fetchResponsesMessage(body: any) {
+interface FetchResponseOptions {
+  logUsageCost?: UsageCostLogger;
+  source?: string;
+  metadata?: Record<string, any>;
+}
+
+async function fetchResponsesMessage(body: any, options: FetchResponseOptions = {}) {
+  const { logUsageCost, source = 'responses', metadata } = options;
   const response = await fetch('/api/responses', {
     method: 'POST',
     headers: {
@@ -163,6 +172,20 @@ async function fetchResponsesMessage(body: any) {
   }
 
   const completion = await response.json();
+
+  if (logUsageCost && completion?.usage) {
+    logUsageCost({
+      model: body.model,
+      source,
+      usage: completion.usage,
+      metadata: {
+        ...(metadata ?? {}),
+        responseId: completion.id,
+        usageNormalized: normalizeUsage(completion.usage),
+      },
+    });
+  }
+
   return completion;
 }
 
@@ -187,6 +210,7 @@ async function handleToolCalls(
   body: any,
   response: any,
   addBreadcrumb?: (title: string, data?: any) => void,
+  logUsageCost?: UsageCostLogger,
 ) {
   let currentResponse = response;
 
@@ -249,7 +273,14 @@ async function handleToolCalls(
     }
 
     // Make the follow-up request including the tool outputs.
-    currentResponse = await fetchResponsesMessage(body);
+    currentResponse = await fetchResponsesMessage(body, {
+      logUsageCost,
+      source: 'responses.supervisor.follow_up',
+      metadata: {
+        phase: 'follow_up',
+        lastToolCall: toolCall.name,
+      },
+    });
   }
 }
 
@@ -303,12 +334,20 @@ export const getNextResponseFromSupervisor = tool({
       tools: supervisorAgentTools,
     };
 
-    const response = await fetchResponsesMessage(body);
+    const logUsageCost = (details?.context as any)?.logUsageCost as
+      | UsageCostLogger
+      | undefined;
+
+    const response = await fetchResponsesMessage(body, {
+      logUsageCost,
+      source: 'responses.supervisor.initial',
+      metadata: { phase: 'initial' },
+    });
     if (response.error) {
       return { error: 'Something went wrong.' };
     }
 
-    const finalText = await handleToolCalls(body, response, addBreadcrumb);
+    const finalText = await handleToolCalls(body, response, addBreadcrumb, logUsageCost);
     if ((finalText as any)?.error) {
       return { error: 'Something went wrong.' };
     }

--- a/src/app/agentConfigs/guardrails.ts
+++ b/src/app/agentConfigs/guardrails.ts
@@ -1,5 +1,6 @@
 import { zodTextFormat } from 'openai/helpers/zod';
-import { GuardrailOutputZod, GuardrailOutput } from '@/app/types';
+import { GuardrailOutputZod, GuardrailOutput, UsageCostLogger } from '@/app/types';
+import { normalizeUsage } from '@/app/lib/cost';
 
 // Validator that calls the /api/responses endpoint to
 // validates the realtime output according to moderation policies. 
@@ -8,6 +9,7 @@ import { GuardrailOutputZod, GuardrailOutput } from '@/app/types';
 export async function runGuardrailClassifier(
   message: string,
   companyName: string = 'newTelco',
+  logUsageCost?: UsageCostLogger,
 ): Promise<GuardrailOutput> {
   const messages = [
     {
@@ -53,6 +55,20 @@ export async function runGuardrailClassifier(
 
   const data = await response.json();
 
+  if (logUsageCost && data?.usage) {
+    logUsageCost({
+      model: 'gpt-4o-mini',
+      source: 'guardrail',
+      usage: data.usage,
+      metadata: {
+        guardrail: 'moderation_guardrail',
+        companyName,
+        responseId: data.id,
+        usageNormalized: normalizeUsage(data.usage),
+      },
+    });
+  }
+
   try {
     const output = GuardrailOutputZod.parse(data.output_parsed);
     return {
@@ -77,13 +93,16 @@ export interface RealtimeOutputGuardrailArgs {
 }
 
 // Creates a guardrail bound to a specific company name for output moderation purposes. 
-export function createModerationGuardrail(companyName: string) {
+export function createModerationGuardrail(
+  companyName: string,
+  logUsageCost?: UsageCostLogger,
+) {
   return {
     name: 'moderation_guardrail',
 
     async execute({ agentOutput }: RealtimeOutputGuardrailArgs): Promise<RealtimeOutputGuardrailResult> {
       try {
-        const res = await runGuardrailClassifier(agentOutput, companyName);
+        const res = await runGuardrailClassifier(agentOutput, companyName, logUsageCost);
         const triggered = res.moderationCategory !== 'NONE';
         return {
           tripwireTriggered: triggered,

--- a/src/app/contexts/EventContext.tsx
+++ b/src/app/contexts/EventContext.tsx
@@ -2,7 +2,14 @@
 
 import React, { createContext, useContext, useState, FC, PropsWithChildren } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { LoggedEvent } from "@/app/types";
+import { LoggedEvent, UsageCostLogger, UsageLogPayload, UsageCostTotals } from "@/app/types";
+import {
+  accumulateTotals,
+  calculateUsageCost,
+  emptyUsageTotals,
+  getPricingForModel,
+  normalizeUsage,
+} from "@/app/lib/cost";
 
 type EventContextValue = {
   loggedEvents: LoggedEvent[];
@@ -10,12 +17,15 @@ type EventContextValue = {
   logServerEvent: (eventObj: Record<string, any>, eventNameSuffix?: string) => void;
   logHistoryItem: (item: any) => void;
   toggleExpand: (id: number | string) => void;
+  usageTotals: Record<string, UsageCostTotals>;
+  logUsageCost: UsageCostLogger;
 };
 
 const EventContext = createContext<EventContextValue | undefined>(undefined);
 
 export const EventProvider: FC<PropsWithChildren> = ({ children }) => {
   const [loggedEvents, setLoggedEvents] = useState<LoggedEvent[]>([]);
+  const [usageTotals, setUsageTotals] = useState<Record<string, UsageCostTotals>>({});
 
   function addLoggedEvent(direction: "client" | "server", eventName: string, eventData: Record<string, any>) {
     const id = eventData.event_id || uuidv4();
@@ -64,10 +74,74 @@ export const EventProvider: FC<PropsWithChildren> = ({ children }) => {
     );
   };
 
+  const logUsageCost: EventContextValue['logUsageCost'] = (payload: UsageLogPayload) => {
+    if (!payload) return;
+    const usageDelta = normalizeUsage(payload.usage);
+    if (
+      usageDelta.inputTokens === 0 &&
+      usageDelta.outputTokens === 0 &&
+      usageDelta.totalTokens === 0
+    ) {
+      return;
+    }
+
+    setUsageTotals((prev) => {
+      const pricingInfo = getPricingForModel(payload.model);
+      const resolvedModel = pricingInfo?.resolvedModel ?? payload.model;
+      const pricing = pricingInfo?.pricing;
+      const existingTotals = prev[resolvedModel] ?? emptyUsageTotals();
+      const costDelta = pricing ? calculateUsageCost(usageDelta, pricing) : null;
+      const updatedTotals = accumulateTotals(existingTotals, usageDelta, costDelta);
+      const nextTotals = {
+        ...prev,
+        [resolvedModel]: updatedTotals,
+      };
+
+      const overallTotals = Object.values(nextTotals).reduce<UsageCostTotals>(
+        (acc, totals) => ({
+          inputTokens: acc.inputTokens + totals.inputTokens,
+          outputTokens: acc.outputTokens + totals.outputTokens,
+          totalTokens: acc.totalTokens + totals.totalTokens,
+          inputCost: acc.inputCost + totals.inputCost,
+          outputCost: acc.outputCost + totals.outputCost,
+          totalCost: acc.totalCost + totals.totalCost,
+        }),
+        emptyUsageTotals(),
+      );
+
+      addLoggedEvent(
+        "server",
+        `usage_cost.${payload.source || "usage"}`,
+        {
+          model: payload.model,
+          resolvedModel,
+          source: payload.source,
+          usageDelta,
+          deltaCostUSD: costDelta,
+          pricing: pricing ?? null,
+          totalsForModel: updatedTotals,
+          totalsOverall: overallTotals,
+          pricingAvailable: Boolean(pricing),
+          metadata: payload.metadata ?? {},
+        },
+      );
+
+      return nextTotals;
+    });
+  };
+
 
   return (
     <EventContext.Provider
-      value={{ loggedEvents, logClientEvent, logServerEvent, logHistoryItem, toggleExpand }}
+      value={{
+        loggedEvents,
+        logClientEvent,
+        logServerEvent,
+        logHistoryItem,
+        toggleExpand,
+        usageTotals,
+        logUsageCost,
+      }}
     >
       {children}
     </EventContext.Provider>

--- a/src/app/hooks/useRealtimeSession.ts
+++ b/src/app/hooks/useRealtimeSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   RealtimeSession,
   RealtimeAgent,
@@ -9,6 +9,7 @@ import { audioFormatForCodec, applyCodecPreferences } from '../lib/codecUtils';
 import { useEvent } from '../contexts/EventContext';
 import { useHandleSessionHistory } from './useHandleSessionHistory';
 import { SessionStatus } from '../types';
+import { normalizeUsage } from '../lib/cost';
 
 export interface RealtimeSessionCallbacks {
   onConnectionChange?: (status: SessionStatus) => void;
@@ -23,12 +24,14 @@ export interface ConnectOptions {
   outputGuardrails?: any[];
 }
 
+const REALTIME_MODEL = 'gpt-4o-realtime-preview-2025-06-03';
+
 export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
   const sessionRef = useRef<RealtimeSession | null>(null);
   const [status, setStatus] = useState<
     SessionStatus
   >('DISCONNECTED');
-  const { logClientEvent } = useEvent();
+  const { logClientEvent, logServerEvent, logUsageCost } = useEvent();
 
   const updateStatus = useCallback(
     (s: SessionStatus) => {
@@ -36,34 +39,36 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
       callbacks.onConnectionChange?.(s);
       logClientEvent({}, s);
     },
-    [callbacks],
+    [callbacks, logClientEvent],
   );
 
-  const { logServerEvent } = useEvent();
+  const historyHandlersRef = useHandleSessionHistory();
 
-  const historyHandlers = useHandleSessionHistory().current;
-
-  function handleTransportEvent(event: any) {
+  const handleTransportEvent = useCallback(
+    (event: any) => {
+      const historyHandlers = historyHandlersRef.current;
     // Handle additional server events that aren't managed by the session
-    switch (event.type) {
-      case "conversation.item.input_audio_transcription.completed": {
-        historyHandlers.handleTranscriptionCompleted(event);
-        break;
+      switch (event.type) {
+        case "conversation.item.input_audio_transcription.completed": {
+          historyHandlers.handleTranscriptionCompleted(event);
+          break;
+        }
+        case "response.audio_transcript.done": {
+          historyHandlers.handleTranscriptionCompleted(event);
+          break;
+        }
+        case "response.audio_transcript.delta": {
+          historyHandlers.handleTranscriptionDelta(event);
+          break;
+        }
+        default: {
+          logServerEvent(event);
+          break;
+        }
       }
-      case "response.audio_transcript.done": {
-        historyHandlers.handleTranscriptionCompleted(event);
-        break;
-      }
-      case "response.audio_transcript.delta": {
-        historyHandlers.handleTranscriptionDelta(event);
-        break;
-      }
-      default: {
-        logServerEvent(event);
-        break;
-      } 
-    }
-  }
+    },
+    [historyHandlersRef, logServerEvent],
+  );
 
   const codecParamRef = useRef<string>(
     (typeof window !== 'undefined'
@@ -78,35 +83,15 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
     [],
   );
 
-  const handleAgentHandoff = (item: any) => {
-    const history = item.context.history;
-    const lastMessage = history[history.length - 1];
-    const agentName = lastMessage.name.split("transfer_to_")[1];
-    callbacks.onAgentHandoff?.(agentName);
-  };
-
-  useEffect(() => {
-    if (sessionRef.current) {
-      // Log server errors
-      sessionRef.current.on("error", (...args: any[]) => {
-        logServerEvent({
-          type: "error",
-          message: args[0],
-        });
-      });
-
-      // history events
-      sessionRef.current.on("agent_handoff", handleAgentHandoff);
-      sessionRef.current.on("agent_tool_start", historyHandlers.handleAgentToolStart);
-      sessionRef.current.on("agent_tool_end", historyHandlers.handleAgentToolEnd);
-      sessionRef.current.on("history_updated", historyHandlers.handleHistoryUpdated);
-      sessionRef.current.on("history_added", historyHandlers.handleHistoryAdded);
-      sessionRef.current.on("guardrail_tripped", historyHandlers.handleGuardrailTripped);
-
-      // additional transport events
-      sessionRef.current.on("transport_event", handleTransportEvent);
-    }
-  }, [sessionRef.current]);
+  const handleAgentHandoff = useCallback(
+    (item: any) => {
+      const history = item.context.history;
+      const lastMessage = history[history.length - 1];
+      const agentName = lastMessage.name.split("transfer_to_")[1];
+      callbacks.onAgentHandoff?.(agentName);
+    },
+    [callbacks],
+  );
 
   const connect = useCallback(
     async ({
@@ -137,7 +122,7 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
             return pc;
           },
         }),
-        model: 'gpt-4o-realtime-preview-2025-06-03',
+        model: REALTIME_MODEL,
         config: {
           inputAudioFormat: audioFormat,
           outputAudioFormat: audioFormat,
@@ -149,10 +134,39 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
         context: extraContext ?? {},
       });
 
+      const session = sessionRef.current;
+      const historyHandlers = historyHandlersRef.current;
+
+      session.on("error", (...args: any[]) => {
+        logServerEvent({
+          type: "error",
+          message: args[0],
+        });
+      });
+
+      session.on("agent_handoff", handleAgentHandoff);
+      session.on("agent_tool_start", historyHandlers.handleAgentToolStart);
+      session.on("agent_tool_end", historyHandlers.handleAgentToolEnd);
+      session.on("history_updated", historyHandlers.handleHistoryUpdated);
+      session.on("history_added", historyHandlers.handleHistoryAdded);
+      session.on("guardrail_tripped", historyHandlers.handleGuardrailTripped);
+      session.on("transport_event", handleTransportEvent);
+      session.on("usage_update", (usage) => {
+        logUsageCost({
+          model: REALTIME_MODEL,
+          source: "realtime",
+          usage,
+          metadata: {
+            requests: usage.requests,
+            sessionTotals: normalizeUsage(session.usage),
+          },
+        });
+      });
+
       await sessionRef.current.connect({ apiKey: ek });
       updateStatus('CONNECTED');
     },
-    [callbacks, updateStatus],
+    [applyCodec, callbacks, handleAgentHandoff, handleTransportEvent, historyHandlersRef, logServerEvent, logUsageCost, updateStatus],
   );
 
   const disconnect = useCallback(() => {

--- a/src/app/lib/cost.ts
+++ b/src/app/lib/cost.ts
@@ -1,0 +1,197 @@
+export type ModelCategory = "text" | "realtime";
+
+export interface ModelPricing {
+  /** Friendly identifier for the pricing entry. */
+  name: string;
+  /** The usage category (text or realtime) for the model. */
+  category: ModelCategory;
+  /** Cost in USD per one million input tokens. */
+  inputCostPerMillion: number;
+  /** Cost in USD per one million output tokens. */
+  outputCostPerMillion: number;
+}
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface CostBreakdown {
+  inputCost: number;
+  outputCost: number;
+  totalCost: number;
+}
+
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  /**
+   * GPT-4o Realtime models share the same token billing as GPT-4o (USD $5 / 1M input, $15 / 1M output).
+   * Source: https://openai.com/pricing
+   */
+  "gpt-4o-realtime": {
+    name: "GPT-4o Realtime",
+    category: "realtime",
+    inputCostPerMillion: 5,
+    outputCostPerMillion: 15,
+  },
+  /**
+   * GPT-4o models (text or JSON) share the same pricing as realtime, included for completeness.
+   */
+  "gpt-4o": {
+    name: "GPT-4o",
+    category: "text",
+    inputCostPerMillion: 5,
+    outputCostPerMillion: 15,
+  },
+  /**
+   * GPT-4.1 text-based Responses API pricing (USD $15 / 1M input, $60 / 1M output).
+   */
+  "gpt-4.1": {
+    name: "GPT-4.1",
+    category: "text",
+    inputCostPerMillion: 15,
+    outputCostPerMillion: 60,
+  },
+  /**
+   * GPT-4o mini pricing (USD $0.15 / 1M input, $0.60 / 1M output).
+   */
+  "gpt-4o-mini": {
+    name: "GPT-4o mini",
+    category: "text",
+    inputCostPerMillion: 0.15,
+    outputCostPerMillion: 0.6,
+  },
+};
+
+function cloneTotals(): TokenUsage & CostBreakdown {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCost: 0,
+    outputCost: 0,
+    totalCost: 0,
+  };
+}
+
+export function emptyUsageTotals(): TokenUsage & CostBreakdown {
+  return cloneTotals();
+}
+
+const PRICING_KEYS = Object.keys(MODEL_PRICING);
+
+/**
+ * Resolve pricing information for a given model string. Handles versioned names by matching
+ * the longest pricing key that is a prefix of the provided model.
+ */
+export function getPricingForModel(model: string):
+  | { resolvedModel: string; pricing: ModelPricing }
+  | null {
+  if (!model) return null;
+  const exact = MODEL_PRICING[model];
+  if (exact) {
+    return { resolvedModel: model, pricing: exact };
+  }
+
+  const lowerModel = model.toLowerCase();
+  let bestMatch: string | null = null;
+  for (const key of PRICING_KEYS) {
+    if (lowerModel.startsWith(key.toLowerCase())) {
+      if (!bestMatch || key.length > bestMatch.length) {
+        bestMatch = key;
+      }
+    }
+  }
+
+  if (!bestMatch) {
+    return null;
+  }
+
+  return { resolvedModel: bestMatch, pricing: MODEL_PRICING[bestMatch] };
+}
+
+/**
+ * Normalizes a variety of usage payload shapes into a consistent token usage object.
+ */
+export function normalizeUsage(rawUsage: any): TokenUsage {
+  if (!rawUsage || typeof rawUsage !== "object") {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+
+  const inputCandidates = [
+    rawUsage.inputTokens,
+    rawUsage.input_tokens,
+    rawUsage.prompt_tokens,
+    rawUsage.promptTokens,
+    rawUsage.input,
+  ];
+  const outputCandidates = [
+    rawUsage.outputTokens,
+    rawUsage.output_tokens,
+    rawUsage.completion_tokens,
+    rawUsage.completionTokens,
+    rawUsage.output,
+  ];
+  const totalCandidates = [
+    rawUsage.totalTokens,
+    rawUsage.total_tokens,
+    rawUsage.total,
+  ];
+
+  const pickNumber = (values: any[]): number => {
+    for (const value of values) {
+      if (typeof value === "number" && Number.isFinite(value)) return value;
+      if (typeof value === "string") {
+        const parsed = Number(value);
+        if (!Number.isNaN(parsed)) return parsed;
+      }
+    }
+    return 0;
+  };
+
+  const inputTokens = pickNumber(inputCandidates);
+  const outputTokens = pickNumber(outputCandidates);
+  const totalTokensCandidate = pickNumber(totalCandidates);
+  const totalTokens = totalTokensCandidate || inputTokens + outputTokens;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+  };
+}
+
+export function calculateUsageCost(
+  usage: TokenUsage,
+  pricing: ModelPricing,
+  precision: number = 6,
+): CostBreakdown {
+  const factor = 1_000_000;
+
+  const round = (value: number) => {
+    const multiplier = 10 ** precision;
+    return Math.round(value * multiplier) / multiplier;
+  };
+
+  const inputCost = round((usage.inputTokens / factor) * pricing.inputCostPerMillion);
+  const outputCost = round((usage.outputTokens / factor) * pricing.outputCostPerMillion);
+  const totalCost = round(inputCost + outputCost);
+
+  return { inputCost, outputCost, totalCost };
+}
+
+export function accumulateTotals(
+  base: TokenUsage & CostBreakdown,
+  delta: TokenUsage,
+  costDelta?: CostBreakdown | null,
+): TokenUsage & CostBreakdown {
+  return {
+    inputTokens: base.inputTokens + delta.inputTokens,
+    outputTokens: base.outputTokens + delta.outputTokens,
+    totalTokens: base.totalTokens + delta.totalTokens,
+    inputCost: base.inputCost + (costDelta?.inputCost ?? 0),
+    outputCost: base.outputCost + (costDelta?.outputCost ?? 0),
+    totalCost: base.totalCost + (costDelta?.totalCost ?? 0),
+  };
+}
+

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { CostBreakdown, TokenUsage } from "@/app/lib/cost";
 
 // Define the allowed moderation categories only once
 export const MODERATION_CATEGORIES = [
@@ -146,3 +147,16 @@ export const GuardrailOutputZod = z.object({
 });
 
 export type GuardrailOutput = z.infer<typeof GuardrailOutputZod>;
+
+export type UsageDeltaPayload = Partial<TokenUsage> | Record<string, any> | null | undefined;
+
+export interface UsageLogPayload {
+  model: string;
+  source: "realtime" | "responses" | "guardrail" | string;
+  usage: UsageDeltaPayload;
+  metadata?: Record<string, any>;
+}
+
+export type UsageCostTotals = TokenUsage & CostBreakdown;
+
+export type UsageCostLogger = (payload: UsageLogPayload) => void;


### PR DESCRIPTION
## Summary
- add reusable pricing utilities to normalize usage data and compute USD costs for supported models
- extend the event context to track per-model and aggregate usage totals and expose a cost logger
- hook the realtime session, guardrails, and supervisor responses into the cost logger so usage updates are recorded with metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca5070692c832a977ccd06590737a7